### PR TITLE
Add ark binary

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,8 +1,8 @@
 # Use Google Cloud SDK image from Docker Hub as our base
 FROM google/cloud-sdk:183.0.0-alpine
 
-# Install openssl (for kubectl), gcloud alpha and beta extensions,
-# kubectl binary, helm binary, and terraform binary
+# Install openssl (used for kubectl), tar, gcloud alpha and beta extensions,
+# kubectl, helm, terraform, terragrunt, ark, and terraform-provider-helm plugin
 RUN apk add --no-cache \
         openssl \
         tar \

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -5,16 +5,33 @@ FROM google/cloud-sdk:183.0.0-alpine
 # kubectl binary, helm binary, and terraform binary
 RUN apk add --no-cache \
         openssl \
+        tar \
+        \
         && gcloud components install alpha beta kubectl \
+        \
         && curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash \
         && curl -o ./terraform.zip https://releases.hashicorp.com/terraform/0.11.2/terraform_0.11.2_linux_amd64.zip \
         && unzip terraform.zip \
         && mv terraform /usr/bin \
-        && curl -L -o ./terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.13.23/terragrunt_linux_amd64 \
+        && rm -rf terraform.zip \
+        \
+        && curl -L -o ./terragrunt \
+        https://github.com/gruntwork-io/terragrunt/releases/download/v0.13.23/terragrunt_linux_amd64 \
         && chmod 0700 terragrunt \
-        && mv terragrunt /usr/bin
+        && mv terragrunt /usr/bin \
+        \
+        && curl -L -o ./ark.tar.gz \
+        https://github.com/heptio/ark/releases/download/v0.6.0/ark-v0.6.0-linux-amd64.tar.gz \
+        && tar -xvzf ark.tar.gz \
+        && rm -rf ark.tar.gz \
+        && chmod 0700 ark \
+        && mv ark /usr/bin \
+        \
+        && curl -L -o ./terraform-provider-helm_v0.6.0 \
+        https://github.com/burdiyan/terraform-provider-helm/releases/download/v0.6.0/terraform-provider-helm_linux_amd64 \
+        && chmod 0700 terraform-provider-helm_v0.6.0 \
+        && mkdir -p /root/.terraform.d/plugins/ \
+        && mv terraform-provider-helm_v0.6.0 /root/.terraform.d/plugins/
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT [ "docker-entrypoint.sh" ]
-
-COPY vendor/terraform-provider-helm_linux_amd64 /root/.terraform.d/plugins/terraform-provider-helm_v0.6.0

--- a/backup/ark/01-prereqs.yaml
+++ b/backup/ark/01-prereqs.yaml
@@ -1,0 +1,152 @@
+# Copyright 2017 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: backups
+    kind: Backup
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: schedules.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: schedules
+    kind: Schedule
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: restores
+    kind: Restore
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: configs.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: configs
+    kind: Config
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: downloadrequests.ark.heptio.com
+  labels:
+    component: ark
+spec:
+  group: ark.heptio.com
+  version: v1
+  scope: Namespaced
+  names:
+    plural: downloadrequests
+    kind: DownloadRequest
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: heptio-ark
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ark
+  namespace: heptio-ark
+  labels:
+    component: ark
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ark
+  labels:
+    component: ark
+subjects:
+  - kind: ServiceAccount
+    namespace: heptio-ark
+    name: ark
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: heptio-ark
+  name: ark
+  labels:
+    component: ark
+rules:
+  - apiGroups:
+      - ark.heptio.com
+    verbs:
+      - "*"
+    resources:
+      - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  namespace: heptio-ark
+  name: ark
+  labels:
+    component: ark
+subjects:
+  - kind: ServiceAccount
+    namespace: heptio-ark
+    name: ark
+roleRef:
+  kind: Role
+  name: ark
+  apiGroup: rbac.authorization.k8s.io

--- a/backup/ark/02-config.yaml
+++ b/backup/ark/02-config.yaml
@@ -1,0 +1,121 @@
+# Copyright 2017 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: ark.heptio.com/v1
+kind: Config
+metadata:
+  namespace: heptio-ark
+  name: default
+backupStorageProvider:
+  name: aws
+  bucket: ark
+  config:
+    region: minio
+    s3ForcePathStyle: "true"
+    s3Url: http://minio.heptio-ark.svc:9000
+backupSyncPeriod: 1m
+gcSyncPeriod: 1m
+scheduleSyncPeriod: 1m
+restoreOnlyMode: false
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  namespace: heptio-ark
+  name: minio
+  labels:
+    component: minio
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        component: minio
+    spec:
+      volumes:
+      - name: storage
+        hostPath:
+          path: /tmp/minio
+      containers:
+      - name: minio
+        image: minio/minio:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - server
+        - /storage
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - name: storage
+          mountPath: "/storage"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: heptio-ark
+  name: minio
+  labels:
+    component: minio
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    component: minio
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: heptio-ark
+  name: cloud-credentials
+  labels:
+    component: minio
+stringData:
+  cloud: |
+    [default]
+    aws_access_key_id = minio
+    aws_secret_access_key = minio123
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: heptio-ark
+  name: minio-setup
+  labels:
+    component: minio
+spec:
+  template:
+    metadata:
+      name: minio-setup
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: mc
+        image: minio/mc:latest
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mc config host add ark http://minio:9000 minio minio123 && mc mb -p ark/ark"

--- a/backup/ark/03-deployment.yaml
+++ b/backup/ark/03-deployment.yaml
@@ -1,0 +1,50 @@
+# Copyright 2017 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  namespace: heptio-ark
+  name: ark
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: ark
+    spec:
+      restartPolicy: Always
+      serviceAccountName: ark
+      containers:
+        - name: ark
+          image: gcr.io/heptio-images/ark:latest
+          command:
+            - /ark
+          args:
+            - server
+          volumeMounts:
+            - name: cloud-credentials
+              mountPath: /credentials
+            - name: plugins
+              mountPath: /plugins
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /credentials/cloud
+      volumes:
+        - name: cloud-credentials
+          secret:
+            secretName: cloud-credentials
+        - name: plugins
+          emptyDir: {}


### PR DESCRIPTION
We'll use Heptio Ark to backup important assets that need to be persisted beyond the lifetime of a Kubernetes cluster.

This PR adds a `backup` directory that also contains a quick and dirty bash script for persisting kube-lego TLS certificates onto our local machine to `backup/tls/secret.yaml`. Metadata from that file needs to be deleted manually after generation. We can now reuse previously generated (on a different cluster) kube-lego certs.