### PR TITLE
Refactor xk-release module inputs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,37 @@
 #!/bin/bash
 
+# ------------------------------------------------------------------------------
+# COMMON VARS
+# ------------------------------------------------------------------------------
+
 export XK_LIVE_DIR='/exekube/live/prod'
 export TF_VAR_gcp_project='my-project-186217'
 export TF_VAR_gcp_remote_state_bucket='my-project-terraform-state'
 
-export TF_VAR_cloudflare='{ email = "account@example.com", token = "123456f789631d3215ddaa332f89c9f8a64d15" }'
-export TF_VAR_release_spec='{ chartrepo_username = "charts-admin", chartrepo_password = "cool-safe--p455w0rd", registry_username = "registry-admin", registry_password = "another-cool-safe-p455w0rd" }'
+# ------------------------------------------------------------------------------
+# AUTHENTICATION
+# ------------------------------------------------------------------------------
+
+export TF_VAR_cloudflare_auth=$(cat <<EOF
+{
+        email = "account@example.com",
+        token = "123456f789631d3215ddaa332f89c9f8a64d15"
+}
+EOF
+)
+
+export TF_VAR_registry_auth=$(cat <<EOF
+{
+        username = "registry-admin",
+        password = "cool-safe-p455w0rd"
+}
+EOF
+)
+
+export TF_VAR_chartrepo_auth=$(cat <<EOF
+{
+        username = "charts-admin",
+        password = "cool-safe-p455w0rd"
+}
+EOF
+)

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *credentials.json
 config
-bin
 .archive
 .env
 live/**/docker
@@ -13,4 +12,3 @@ backup/tls
 # .tfstate files
 *.tfstate
 *.tfstate.*
-# *.tfvars

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,8 +12,9 @@ services:
       XK_LIVE_DIR:
       TF_VAR_gcp_project:
       TF_VAR_gcp_remote_state_bucket:
-      TF_VAR_cloudflare:
-      TF_VAR_release_spec:
+      TF_VAR_cloudflare_auth:
+      TF_VAR_registry_auth:
+      TF_VAR_chartrepo_auth:
     ports:
       - 8001:8001
     volumes:

--- a/live/prod/apps/rails-app/inputs.tfvars
+++ b/live/prod/apps/rails-app/inputs.tfvars
@@ -7,6 +7,5 @@ release_spec = {
   chart_name    = "rails-app"
   chart_version = "0.1.1"
 
-  pull_secret = "docker-config.json"
   domain_name = "react.swarm.pw"
 }

--- a/live/prod/apps/rails-app/values.yaml
+++ b/live/prod/apps/rails-app/values.yaml
@@ -3,7 +3,7 @@ image:
   repository: registry.swarm.pw/rails-react-boilerplate
   tag: "0.1.3"
   pullPolicy: Always
-  pullSecret: docker-config-json
+  pullSecret: registry-dockercfg
 ingress:
   enabled: true
   annotations:

--- a/live/prod/ci/chartmuseum/inputs.tfvars
+++ b/live/prod/ci/chartmuseum/inputs.tfvars
@@ -1,3 +1,7 @@
+basic_auth_secret = {
+  file = "chartrepo.htpasswd"
+}
+
 release_spec = {
   enabled        = true
   release_name   = "chartmuseum"
@@ -8,8 +12,6 @@ release_spec = {
   chart_version = "0.3.1"
 
   domain_name = "charts.swarm.pw"
-
-  basic_auth = "chartrepo.htpasswd"
 
   post_hook = "sleep 15"
 }

--- a/live/prod/ci/docker-registry/inputs.tfvars
+++ b/live/prod/ci/docker-registry/inputs.tfvars
@@ -1,17 +1,17 @@
+basic_auth_secret = {
+  file = "registry.htpasswd"
+}
+
 release_spec = {
   enabled     = true
   domain_name = "registry.swarm.pw"
 
-  release_name   = "registry"
+  release_name   = "docker-registry"
   release_values = "values.yaml"
 
   chart_repo    = "stable"
   chart_name    = "docker-registry"
   chart_version = "1.0.1"
 
-  basic_auth = "registry.htpasswd"
-
-  post_hook = <<-EOF
-              sleep 5 && helm repo update
-              EOF
+  post_hook = "sleep 5 && helm repo update"
 }

--- a/modules/xk-release/config.tf
+++ b/modules/xk-release/config.tf
@@ -1,13 +1,12 @@
 terraform {
-  # The configuration for this backend will be filled in by Terragrunt
   backend "gcs" {}
 }
 
 provider "helm" {}
 
 provider "cloudflare" {
-  email = "${var.cloudflare["email"]}"
-  token = "${var.cloudflare["token"]}"
+  email = "${var.cloudflare_auth["email"]}"
+  token = "${var.cloudflare_auth["token"]}"
 }
 
 provider "kubernetes" {}

--- a/modules/xk-release/inputs.tf
+++ b/modules/xk-release/inputs.tf
@@ -1,23 +1,4 @@
 # ------------------------------------------------------------------------------
-# CloudFlare input variables
-# ------------------------------------------------------------------------------
-
-variable "cloudflare" {
-  type = "map"
-
-  default = {
-    email = ""
-    token = ""
-  }
-}
-
-variable "cluster_dns_zones" {
-  type = "list"
-
-  default = []
-}
-
-# ------------------------------------------------------------------------------
 # Helm release input variables
 # ------------------------------------------------------------------------------
 
@@ -35,12 +16,59 @@ variable "release_spec" {
 
     domain_name = ""
 
-    chartrepo_username = ""
-    chartrepo_password = ""
+    create_pull_secret = false
+  }
+}
 
-    basic_auth        = ""
-    pull_secret       = ""
-    registry_username = ""
-    registry_password = ""
+# ------------------------------------------------------------------------------
+# Point DNS zones to our cloud load balancer IP address
+# ------------------------------------------------------------------------------
+
+variable "cluster_dns_zones" {
+  type = "list"
+
+  default = []
+}
+
+# ------------------------------------------------------------------------------
+# Kubernetes secret inputs
+# ------------------------------------------------------------------------------
+
+variable "basic_auth_secret" {
+  type = "map"
+
+  default = {
+    file = ""
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Credentials for use as client, can be filled by local environmental variables
+# ------------------------------------------------------------------------------
+
+variable "cloudflare_auth" {
+  type = "map"
+
+  default = {
+    email = ""
+    token = ""
+  }
+}
+
+variable "registry_auth" {
+  type = "map"
+
+  default = {
+    username = ""
+    password = ""
+  }
+}
+
+variable "chartrepo_auth" {
+  type = "map"
+
+  default = {
+    username = ""
+    password = ""
   }
 }

--- a/modules/xk-release/resources.tf
+++ b/modules/xk-release/resources.tf
@@ -1,46 +1,5 @@
 # ------------------------------------------------------------------------------
-# Use LoadBalancer IP to create a CloudFlare DNS record
-# ------------------------------------------------------------------------------
-
-resource "cloudflare_record" "web" {
-  count = "${var.release_spec["release_name"] == "ingress-controller" ? length(var.cluster_dns_zones) : 0}"
-
-  domain   = "${element(var.cluster_dns_zones, count.index)}"
-  name     = "*"
-  value    = "${data.kubernetes_service.ingress_controller.load_balancer_ingress.0.ip}"
-  type     = "A"
-  ttl      = 120
-  proxied  = false
-  priority = 0
-}
-
-data "kubernetes_service" "ingress_controller" {
-  depends_on = ["helm_release.release"]
-  count      = "${var.release_spec["release_name"] == "ingress-controller" ? 1 : 0}"
-
-  metadata {
-    name = "ingress-controller-nginx-ingress-controller"
-  }
-}
-
-# ------------------------------------------------------------------------------
-# Add private ChertMuseum repo
-# ------------------------------------------------------------------------------
-
-resource "helm_repository" "private" {
-  depends_on = ["helm_release.release"]
-  count      = "${var.release_spec["release_name"] == "chartmuseum" ? 1 : 0}"
-
-  name = "private"
-  url  = "https://${var.release_spec["chartrepo_username"]}:${var.release_spec["chartrepo_password"]}@${var.release_spec["domain_name"]}"
-
-  provisioner "local-exec" {
-    command = "helm repo update"
-  }
-}
-
-# ------------------------------------------------------------------------------
-# Manage a generic Helm release
+# Helm release
 # ------------------------------------------------------------------------------
 
 resource "helm_release" "release" {
@@ -76,30 +35,85 @@ data "template_file" "release_values" {
   }
 }
 
-resource "kubernetes_secret" "basic_auth" {
-  count = "${var.release_spec["basic_auth"] == "" ? 0 : 1}"
+# ------------------------------------------------------------------------------
+# Point DNS zones to our cloud load balancer IP address
+# ------------------------------------------------------------------------------
+
+resource "cloudflare_record" "web" {
+  count = "${var.release_spec["release_name"] == "ingress-controller" ? length(var.cluster_dns_zones) : 0}"
+
+  domain   = "${element(var.cluster_dns_zones, count.index)}"
+  name     = "*"
+  value    = "${data.kubernetes_service.ingress_controller.load_balancer_ingress.0.ip}"
+  type     = "A"
+  ttl      = 120
+  proxied  = false
+  priority = 0
+}
+
+data "kubernetes_service" "ingress_controller" {
+  depends_on = ["helm_release.release"]
+  count      = "${var.release_spec["release_name"] == "ingress-controller" ? 1 : 0}"
 
   metadata {
-    name = "${replace(var.release_spec["basic_auth"], ".", "-")}"
+    name = "ingress-controller-nginx-ingress-controller"
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Basic auth Kubernetes secret
+# ------------------------------------------------------------------------------
+
+resource "kubernetes_secret" "basic_auth" {
+  count = "${var.basic_auth_secret["file"] == "" ? 0 : 1}"
+
+  metadata {
+    name = "${replace(var.basic_auth_secret["file"], ".", "-")}"
   }
 
   data {
-    auth = "${file("${format("%s/%s", path.module, var.release_spec["basic_auth"])}")}"
+    auth = "${file("${format("%s/secrets/%s", path.module, var.basic_auth_secret["file"])}")}"
   }
 
   type = "Opaque"
 }
 
+# ------------------------------------------------------------------------------
+# dockercfg to use as imagePullSecret (dockercfg, dockerconfigjson)
+# ------------------------------------------------------------------------------
+
+locals {
+  dockercfg_auth = "${var.registry_auth["username"]}:${var.registry_auth["password"]}"
+}
+
 resource "kubernetes_secret" "docker_credentials" {
-  count = "${var.release_spec["pull_secret"] == "" ? 0 : 1}"
+  count = "${var.release_spec["release_name"] == "docker-registry" ? 1 : 0}"
 
   metadata {
-    name = "${replace(var.release_spec["pull_secret"], ".", "-")}"
+    name = "registry-dockercfg"
   }
 
   data {
-    ".dockercfg" = "${file("${format("%s/%s", path.module, var.release_spec["pull_secret"])}")}"
+    ".dockercfg" = <<EOF
+{"${var.release_spec["domain_name"]}":{"username":"${var.registry_auth["username"]}","password":"${var.registry_auth["password"]}","email":"","auth":"${base64encode(local.dockercfg_auth)}"}}
+EOF
   }
 
   type = "kubernetes.io/dockercfg"
+}
+
+# ------------------------------------------------------------------------------
+# Private Helm repo
+# ------------------------------------------------------------------------------
+
+resource "helm_repository" "private" {
+  depends_on = ["helm_release.release"]
+  count      = "${var.release_spec["release_name"] == "chartmuseum" ? 1 : 0}"
+
+  name = "private"
+  url  = "https://${var.chartrepo_auth["username"]}:${var.chartrepo_auth["password"]}@${var.release_spec["domain_name"]}"
+
+  provisioner "local-exec" {
+    command = "helm repo update"
+  }
 }


### PR DESCRIPTION
This PR expands the `xk-release` module API so that authentication credentials (like `registry_auth`, `cloudflare_auth`, `chartrepo_auth`) are now separate variables.

Check out https://github.com/ilyasotkov/exekube/blob/c7de93a4e65b559f3d6a54a0074a2d6af4eb4b7f/modules/xk-release/inputs.tf 